### PR TITLE
[SCR-978] Fix/403IdentitiesPermission

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -50,6 +50,9 @@
     },
     "carboncopy": {
       "type": "io.cozy.certified.carbon_copy"
+    },
+    "identities": {
+      "type": "io.cozy.identities"
     }
   },
   "developer": {
@@ -85,6 +88,9 @@
         },
         "carboncopy": {
           "description": "Utilisé pour certifier que vos fichiers sont copie conforme avec les documents d'origine"
+        },
+        "identities": {
+          "description": "Utilise pour sauvegarder votre identité"
         }
       }
     },
@@ -112,6 +118,9 @@
         },
         "carboncopy": {
           "description": "Required for carbon copy documents"
+        },
+        "identities": {
+          "description": "Required to save your identity"
         }
       }
     }
@@ -126,7 +135,8 @@
     "BILLS",
     "CARBON_COPY",
     "DOC_QUALIFICATION_V2",
-    "SENTRY_V2"
+    "SENTRY_V2",
+    "IDENTITY"
   ],
   "manifest_version": "2"
 }


### PR DESCRIPTION
Remove useless cleaning code as it is not needed anymore. Add more log for debug tracking and permissions for identities as it was forgotten when identity scraping was added and was causing the execution to failed on a mysterious 403